### PR TITLE
update dune and add jsoo opens

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -1,3 +1,3 @@
-(lang dune 1.0)
+(lang dune 2.0)
 (name ocamlectron)
 (version 0.0.1)

--- a/example/dune
+++ b/example/dune
@@ -2,8 +2,9 @@
   (name main)
   (js_of_ocaml (flags :standard))
   (preprocess (pps js_of_ocaml-ppx))
-  (libraries 
-    js_of_ocaml 
+  (modes byte js)
+  (libraries
+    js_of_ocaml
     ocamlectron.api
     ocamlectron.main
   )

--- a/example/main.ml
+++ b/example/main.ml
@@ -1,3 +1,4 @@
+open Js_of_ocaml
 open Electron_main
 
 let trace message = 

--- a/lib/electron_api/App.ml
+++ b/lib/electron_api/App.ml
@@ -1,3 +1,4 @@
+open Js_of_ocaml
 open Optional
 
 

--- a/lib/electron_api/App.mli
+++ b/lib/electron_api/App.mli
@@ -6,6 +6,8 @@
     {{: https://electronjs.org/docs/api/app }  ElectronJS : documentation for [app] }
 *)
 
+open Js_of_ocaml
+
 (** {2 Internals types} *)
 
 type t = Electron_plumbing.App.t

--- a/lib/electron_api/BrowserWindow.ml
+++ b/lib/electron_api/BrowserWindow.ml
@@ -1,3 +1,5 @@
+open Js_of_ocaml
+
 type t = Electron_plumbing.BrowserWindow.t
 let singleton electron = electron ##. _BrowserWindow
 

--- a/lib/electron_api/BrowserWindow.mli
+++ b/lib/electron_api/BrowserWindow.mli
@@ -5,6 +5,8 @@
 
 (** {2 Internals types} *)
 
+open Js_of_ocaml
+
 type t = Electron_plumbing.BrowserWindow.t
 
 type title_bar_style = 

--- a/lib/electron_api/Event.ml
+++ b/lib/electron_api/Event.ml
@@ -1,3 +1,5 @@
+open Js_of_ocaml
+
 module EventEmitter = Electron_plumbing.EventEmitter
 
 type 'a t = Js.js_string Js.t

--- a/lib/electron_api/Event.mli
+++ b/lib/electron_api/Event.mli
@@ -1,3 +1,5 @@
+open Js_of_ocaml
+
 (** This module is [Work in progress], his goal is to provides an LWT's API 
     for JavaScript event handlers.
 *)

--- a/lib/electron_api/Optional.ml
+++ b/lib/electron_api/Optional.ml
@@ -1,3 +1,5 @@
+open Js_of_ocaml
+
 module type REQ = 
 sig
   type 'a t

--- a/lib/electron_api/Optional.mli
+++ b/lib/electron_api/Optional.mli
@@ -1,6 +1,7 @@
 (** Helper to work with optional values (empty values or not) to 
     deal with [option], [opt] and [optdef] with a common API. *)
 
+open Js_of_ocaml
 
  (** {2 Interface} *)
 

--- a/lib/electron_api/Os.ml
+++ b/lib/electron_api/Os.ml
@@ -1,3 +1,5 @@
+open Js_of_ocaml
+
 type t =
   | Aix 
   | Darwin 

--- a/lib/electron_api/Process.ml
+++ b/lib/electron_api/Process.ml
@@ -1,3 +1,4 @@
+open Js_of_ocaml
 open Optional
 open Electron_plumbing.Builtin
 

--- a/lib/electron_api/Tools.ml
+++ b/lib/electron_api/Tools.ml
@@ -1,3 +1,5 @@
+open Js_of_ocaml
+
 let require module_name =
   let open Js.Unsafe in
   fun_call

--- a/lib/electron_api/Tools.mli
+++ b/lib/electron_api/Tools.mli
@@ -1,3 +1,5 @@
+open Js_of_ocaml
+
 (** Same of [require] from JavaScript *)
 val require : string -> 'a
 

--- a/lib/electron_api/WebContents.ml
+++ b/lib/electron_api/WebContents.ml
@@ -1,3 +1,5 @@
+open Js_of_ocaml
+
 class type kind = Electron_plumbing.WebContents.web_contents
 
 module S = Electron_plumbing.Struct

--- a/lib/electron_api/WebContents.mli
+++ b/lib/electron_api/WebContents.mli
@@ -2,6 +2,8 @@
 
 (** {2 Types and interfaces} *)
 
+open Js_of_ocaml
+
 class type kind = Electron_plumbing.WebContents.web_contents
 (** Alias for "kind of WebContents" *)
 

--- a/lib/electron_main/Make.ml
+++ b/lib/electron_main/Make.ml
@@ -1,3 +1,5 @@
+open Js_of_ocaml
+
 module type BASIC_APP = 
 sig
   val main_window : unit -> Electron_api.BrowserWindow.t

--- a/lib/electron_plumbing/App.mli
+++ b/lib/electron_plumbing/App.mli
@@ -4,6 +4,7 @@
     {{: https://electronjs.org/docs/api/app }  ElectronJS : documentation for [app] }
 *)
 
+open Js_of_ocaml
 open Js 
 
 class type app = object

--- a/lib/electron_plumbing/BrowserWindow.mli
+++ b/lib/electron_plumbing/BrowserWindow.mli
@@ -3,6 +3,7 @@
     - {{: https://electronjs.org/docs/api/browser-window } Documentation of [BrowserWindow]}
 *)
 
+open Js_of_ocaml
 open Js
 
 (** Define a windows  *)

--- a/lib/electron_plumbing/Builtin.ml
+++ b/lib/electron_plumbing/Builtin.ml
@@ -1,3 +1,4 @@
+open Js_of_ocaml
 open Js
 
 module Promise = 

--- a/lib/electron_plumbing/Builtin.mli
+++ b/lib/electron_plumbing/Builtin.mli
@@ -1,6 +1,6 @@
 (** Built-in JavaScript 's object  *)
 
-
+open Js_of_ocaml
 open Js
 
 module Promise : 

--- a/lib/electron_plumbing/CPUUsage.mli
+++ b/lib/electron_plumbing/CPUUsage.mli
@@ -1,5 +1,6 @@
 (** Data about CPU usage *)
 
+open Js_of_ocaml
 open Js 
 
 class type cpu_usage = object 

--- a/lib/electron_plumbing/ElectronMain.mli
+++ b/lib/electron_plumbing/ElectronMain.mli
@@ -1,5 +1,6 @@
 (** Electron object for Main process *)
 
+open Js_of_ocaml
 open Js
 
 class type electron = object 

--- a/lib/electron_plumbing/Event.mli
+++ b/lib/electron_plumbing/Event.mli
@@ -1,3 +1,4 @@
+open Js_of_ocaml
 open Js 
 
 class type event = object 

--- a/lib/electron_plumbing/EventEmitter.mli
+++ b/lib/electron_plumbing/EventEmitter.mli
@@ -1,3 +1,4 @@
+open Js_of_ocaml
 open Js 
 
 class type emitter = object 

--- a/lib/electron_plumbing/IOCounters.mli
+++ b/lib/electron_plumbing/IOCounters.mli
@@ -1,5 +1,6 @@
 (** Accessors for IO data *)
 
+open Js_of_ocaml
 open Js 
 
 class type io_counters = object 

--- a/lib/electron_plumbing/MemoryUsage.mli
+++ b/lib/electron_plumbing/MemoryUsage.mli
@@ -1,5 +1,6 @@
 (** Memory Usage *)
 
+open Js_of_ocaml
 open Js
 
 class type memory_usage = object 

--- a/lib/electron_plumbing/Position.mli
+++ b/lib/electron_plumbing/Position.mli
@@ -1,5 +1,6 @@
 (** Describe a position *)
 
+open Js_of_ocaml
 open Js 
 
 class type position = object 

--- a/lib/electron_plumbing/PrinterInfo.mli
+++ b/lib/electron_plumbing/PrinterInfo.mli
@@ -1,3 +1,4 @@
+open Js_of_ocaml
 open Js 
 
 class type printer_info = object 

--- a/lib/electron_plumbing/Process.mli
+++ b/lib/electron_plumbing/Process.mli
@@ -8,6 +8,7 @@
     - {{: https://electronjs.org/docs/api/process }  ElectronJS : documentation for [process] } 
 *)
 
+open Js_of_ocaml
 open Js
 
 class type process = object

--- a/lib/electron_plumbing/ProcessMemoryInfo.mli
+++ b/lib/electron_plumbing/ProcessMemoryInfo.mli
@@ -2,6 +2,7 @@
     current process. Note that all statistics are reported in Kilobytes  
 *)
 
+open Js_of_ocaml
 open Js 
 
 class type process_memory_info = object 

--- a/lib/electron_plumbing/Rectangle.mli
+++ b/lib/electron_plumbing/Rectangle.mli
@@ -1,5 +1,7 @@
 (** Describe a Rectangle *)
 
+open Js_of_ocaml
+
 class type rectangle = object 
   inherit Size.size
   inherit Position.position

--- a/lib/electron_plumbing/Referer.mli
+++ b/lib/electron_plumbing/Referer.mli
@@ -1,3 +1,4 @@
+open Js_of_ocaml
 open Js 
 
 class type referer = object 

--- a/lib/electron_plumbing/Release.mli
+++ b/lib/electron_plumbing/Release.mli
@@ -1,5 +1,6 @@
 (** Release Infos *)
 
+open Js_of_ocaml
 open Js 
 
 class type release = object 

--- a/lib/electron_plumbing/Size.mli
+++ b/lib/electron_plumbing/Size.mli
@@ -1,5 +1,6 @@
 (** Describe a Size *)
 
+open Js_of_ocaml
 open Js 
 
 class type size = object 

--- a/lib/electron_plumbing/Struct.ml
+++ b/lib/electron_plumbing/Struct.ml
@@ -1,3 +1,5 @@
+open Js_of_ocaml
+
 module Versions = 
 struct 
 

--- a/lib/electron_plumbing/SystemMemoryInfo.mli
+++ b/lib/electron_plumbing/SystemMemoryInfo.mli
@@ -2,6 +2,7 @@
     Note that all statistics are reported in Kilobytes. 
 *)
 
+open Js_of_ocaml
 open Js 
 
 class type system_memory_info = object 

--- a/lib/electron_plumbing/Task.mli
+++ b/lib/electron_plumbing/Task.mli
@@ -1,3 +1,4 @@
+open Js_of_ocaml
 open Js
 
 class type task = object 

--- a/lib/electron_plumbing/Versions.mli
+++ b/lib/electron_plumbing/Versions.mli
@@ -1,5 +1,5 @@
 (** Versions allowed *)
-
+open Js_of_ocaml
 open Js
 
 class type versions = object 

--- a/lib/electron_plumbing/WebContents.mli
+++ b/lib/electron_plumbing/WebContents.mli
@@ -3,7 +3,7 @@
     - {{: https://electronjs.org/docs/api/web-contents } Documentation for [WebContents]}
 *)
 
-
+open Js_of_ocaml
 open Js
 
 class type web_contents = object 


### PR DESCRIPTION
This updates the dune version and adds Js_of_ocaml opens, since I assume jsoo modules have been reworked in some more recent version. Dune 2.0 also requires explicit modes to be set for targeting js, so I set that in the example.